### PR TITLE
Milestone2/high churn scatter

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -251,7 +251,14 @@ def server(input, output, session):
     @render_widget
     def high_churn_risk():
         df = filtered_df()
-        fig = px.scatter(df)
+        fig = px.scatter(
+            df,
+            x="Lifetime_Value",
+            y="Time_Between_Purchases",
+            color="Retention_Strategy",
+            size="Churn_Probability",
+            size_max=18,
+        )
         return fig
     
     @render_widget

--- a/src/app.py
+++ b/src/app.py
@@ -126,7 +126,6 @@ panel_1 = ui.nav_panel("KPI Tables",
 panel_2 = ui.nav_panel("Churn Risk Plot", 
     ui.layout_columns(
         ui.card(
-            ui.card_header("High Churn Risk Scatterplot"),
             output_widget("high_churn_risk"),
             full_screen=True,
         ),
@@ -263,6 +262,7 @@ def server(input, output, session):
     @render_widget
     def high_churn_risk():
         df = filtered_df()
+        churn_min, churn_max = input.slider_churn()
 
         if df.empty:
             fig = px.scatter(title="No data available for current filters")
@@ -278,7 +278,7 @@ def server(input, output, session):
             hover_data=["Customer_ID", "Region", "Churn_Probability", "Purchase_Frequency"],
         )
         fig.update_layout(
-            title="High Churn Risk Customers by Lifetime Value and Days Between Purchases",
+            title=f"Customers by Lifetime Value and Days Between Purchases, Churn Risk From {churn_min} to {churn_max}",
             xaxis_title="Customer Lifetime Value",
             yaxis_title="Days Between Purchases",
             legend_title="Retention Strategy",

--- a/src/app.py
+++ b/src/app.py
@@ -248,10 +248,11 @@ def server(input, output, session):
         group = mapping[input.row_dropdown()]
         return create_summary_table(filtered_df(), group, "Purchase_Frequency")
 
-    @render.image # Change to widget/plotly for M2
+    @render_widget
     def high_churn_risk():
-        img: ImgData = {"src": "img/markup-user2.png"}
-        return img
+        df = filtered_df()
+        fig = px.scatter(df)
+        return fig
     
     @render_widget
     def heatmap():

--- a/src/app.py
+++ b/src/app.py
@@ -251,6 +251,11 @@ def server(input, output, session):
     @render_widget
     def high_churn_risk():
         df = filtered_df()
+
+        if df.empty:
+            fig = px.scatter(title="No data available for current filters")
+            return fig
+
         fig = px.scatter(
             df,
             x="Lifetime_Value",
@@ -258,6 +263,13 @@ def server(input, output, session):
             color="Retention_Strategy",
             size="Churn_Probability",
             size_max=18,
+            hover_data=["Customer_ID", "Region", "Churn_Probability", "Purchase_Frequency"],
+        )
+        fig.update_layout(
+            title="High Churn Risk Customers by Lifetime Value and Days Between Purchases",
+            xaxis_title="Customer Lifetime Value",
+            yaxis_title="Days Between Purchases",
+            legend_title="Retention Strategy",
         )
         return fig
     

--- a/src/app.py
+++ b/src/app.py
@@ -126,8 +126,7 @@ panel_2 = ui.nav_panel("Churn Risk Plot",
     ui.layout_columns(
         ui.card(
             ui.card_header("High Churn Risk Scatterplot"),
-            ui.output_image("high_churn_risk"), # placeholder, swap with below for M2
-            #output_widget("high_churn_risk"),
+            output_widget("high_churn_risk"),
             full_screen=True,
         ),
         col_widths=[12],


### PR DESCRIPTION
Closes #50

Replaces the static placeholder image in the Churn Risk Plot tab with a fully interactive Plotly scatterplot.

The plot shows customer Lifetime Value on the x-axis and Time Between Purchases on the y-axis. Points are colored by Retention Strategy and sized by Churn Probability, which makes it easy to spot high-risk customers at a glance. Hovering over a point shows the Customer ID, Region, Churn Probability, and Purchase Frequency.

The chart reads directly from the central filtered_df() reactive, so all sidebar filters (churn rate sliders, region checkboxes, retention strategy checkboxes, etc.) immediately update the scatter. When the current filter combination returns no rows, the chart shows a clear "No data available for current filters" message instead of crashing.

Tested locally with the Salescope conda env. Filters for Asia only, churn rate 0.8-1.0, and various strategy combinations all worked as expected.
