### PR TITLE
Add quartile plot to Churn Risk Plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-07
+
+### Added
+- Added a quartile box plot alongside the scatter plot in the Churn Risk Plot tab to show churn probability distributions across retention strategies (Issue #99).
+
 ## [0.2.0] - 2026-02-28
 
 ### Added

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -39,6 +39,7 @@ And these are the updated job stories and their progress as of Milestone 2:
 | `reset` | Input        | `ui.input_action_button()`   | `slider_*`, `check_box_group_*`, `date_range`  | #1, #2, #3 |
 | `filtered_df` | Reactive calc | `@reactive.calc`        | `slider_*`, `check_box_group_*`, `date_range` | #1, #2, #3 |
 | `high_churn_risk` | Output        | `@render_widget`        | `filtered_df`                | #2         |
+| `quartile_churn_risk` | Output    | `@render_widget`        | `filtered_df`                | #2         |
 | `row_dropdown`    | Input         | `ui.input_select()`     | —                            | #1         |
 | `customer_df` | Output        | `@render.data_frame`    | `filtered_df`,`row_dropdown` | #1         |
 | `risk_df`     | Output        | `@render.data_frame`    | `filtered_df`,`row_dropdown` | #1         |
@@ -81,6 +82,7 @@ flowchart TD
   I --> O5([order_df])
   I --> O6([frequency_df])
   F --> O1([high_churn_risk])
+  F --> O8([quartile_churn_risk])
   F --> O2([heatmap])
   F --> O3
   F --> O4
@@ -96,7 +98,7 @@ flowchart TD
 
 - **Inputs:** `slider_churn`, `slider_customer`, `slider_order`, `slider_freq`, `date_range`, `checkbox_group_type`, `checkbox_group_region`, `checkbox_group_strategy`.
 - **Transformation:** Starts with a copy of the full 10,000-row dataset and applies sequential filters. Numeric columns (`Churn_Probability`, `Lifetime_Value`, `Average_Order_Value`, `Purchase_Frequency`) are clipped to the selected slider ranges using `.between()`. The `Launch_Date` column is filtered to the selected date range. Categorical columns (`Most_Frequent_Category`, `Region`, `Retention_Strategy`) are then filtered using `.isin()` based on the selected checkbox values. If a checkbox group has nothing selected, that filter is skipped entirely so the app does not return zero rows unexpectedly.
-- **Outputs:** `high_churn_risk`, `heatmap`, `customer_df`, `risk_df`, `order_df`, `frequency_df`, `kpi_count`.
+- **Outputs:** `high_churn_risk`, `quartile_churn_risk`, `heatmap`, `customer_df`, `risk_df`, `order_df`, `frequency_df`, `kpi_count`.
 
 ## Section 5: Complexity Enhancement — Reset Button
 

--- a/src/app.py
+++ b/src/app.py
@@ -158,7 +158,11 @@ panel_2 = ui.nav_panel("Churn Risk Plot",
             output_widget("high_churn_risk"),
             full_screen=True,
         ),
-        col_widths=[12],
+        ui.card(
+            output_widget("quartile_churn_risk"),
+            full_screen=True,
+        ),
+        col_widths=[8, 4],
     ),
 )
 
@@ -406,6 +410,27 @@ def server(input, output, session):
             xaxis_title="Customer Lifetime Value",
             yaxis_title="Days Between Purchases",
             legend_title="Retention Strategy",
+        )
+        return fig
+    
+    @render_widget
+    def quartile_churn_risk():
+        df = filtered_df()
+        
+        if df.empty:
+            return px.scatter(title="No data available for current filters")
+
+        fig = px.box(
+            df,
+            x="Retention_Strategy",
+            y="Churn_Probability",
+            color="Retention_Strategy",
+        )
+        fig.update_layout(
+            title="Churn Probability quartiles by Retention Strategy",
+            xaxis_title="Retention Strategy",
+            yaxis_title="Churn Probability",
+            showlegend=False
         )
         return fig
     


### PR DESCRIPTION
This PR completes issue #99 by adding a new quartile box plot next to our existing scatter plot in the Churn Risk Plot tab.

- Added a new Plotly box plot (quartile_churn_risk) that shares real estate with the scatter plot (using an 8-column/4-column layout). It runs off the exact same central filtered_df() data and degrades gracefully with a fallback message if the filters return zero rows.
- Updated m2_spec.md components list and reactivity diagram, and added an entry to CHANGELOG.md under [0.3.0]