### PR TITLE
Rework churn filter with min/max inputs and reduction slider 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-07
+
+### Added
+- Replaced the previous churn rate range slider with two independent numerical inputs and a new "Churn rate decrease (%)" slider to directly simulate churn reduction models (Closes #98).
+
 ## [0.2.0] - 2026-02-28
 
 ### Added

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -33,11 +33,12 @@ And these are the updated job stories and their progress as of Milestone 2:
 | ID            | Type          | Shiny widget / renderer | Depends on                   | Job story  |
 | ------------- | ------------- | ----------------------- | ---------------------------- | ---------- |
 | `user-navigation` | Navigation| `ui.navset_bar()`, `ui.nav_panel()` | —             | #1, #2, #3 |
+| `num_churn_*` | Input            | `ui.input_numeric()`        | -                         | #1, #2, #3 |
 | `slider_*` | Input            | `ui.input_slider()`        | -                         | #1, #2, #3 |
 | `check_box_group_*` | Input   | `ui.input_checkbox_group()` | -                        | #1, #2, #3 |
 | `date_range`  | Input         | `ui.input_date_range()`    | -                           | #1, #2, #3 |
-| `reset` | Input        | `ui.input_action_button()`   | `slider_*`, `check_box_group_*`, `date_range`  | #1, #2, #3 |
-| `filtered_df` | Reactive calc | `@reactive.calc`        | `slider_*`, `check_box_group_*`, `date_range` | #1, #2, #3 |
+| `reset` | Input        | `ui.input_action_button()`   | `num_churn_*`, `slider_*`, `check_box_group_*`, `date_range`  | #1, #2, #3 |
+| `filtered_df` | Reactive calc | `@reactive.calc`        | `num_churn_*`, `slider_*`, `check_box_group_*`, `date_range` | #1, #2, #3 |
 | `high_churn_risk` | Output        | `@render_widget`        | `filtered_df`                | #2         |
 | `row_dropdown`    | Input         | `ui.input_select()`     | —                            | #1         |
 | `customer_df` | Output        | `@render.data_frame`    | `filtered_df`,`row_dropdown` | #1         |
@@ -52,7 +53,8 @@ Rows component_4-8 will be filled per issues #57, #58, #59 as implementation pro
 Each of the slider and checkbox components are similar to each other and represent the following components:
 
 ```
-slider_* -> slider_churn, slider_customer, slider_order, slider_freq
+num_churn_* -> num_churn_min, num_churn_max
+slider_* -> slider_churn_decrease, slider_customer, slider_order, slider_freq
 check_box_group_* -> check_box_group_type, check_box_group_region, check_box_group_strategy
 ```
 
@@ -69,7 +71,9 @@ Example:
 ````markdown
 ```mermaid
 flowchart TD
-  A[/slider_churn/] --> F{{filtered_df}}
+  J[/num_churn_min/] --> F{{filtered_df}}
+  K[/num_churn_max/] --> F
+  A[/slider_churn_decrease/] --> F
   B[/slider_customer/] --> F
   C[/slider_order/] --> F
   D[/slider_freq/] --> F
@@ -94,8 +98,8 @@ flowchart TD
 
 ### `filtered_df`
 
-- **Inputs:** `slider_churn`, `slider_customer`, `slider_order`, `slider_freq`, `date_range`, `checkbox_group_type`, `checkbox_group_region`, `checkbox_group_strategy`.
-- **Transformation:** Starts with a copy of the full 10,000-row dataset and applies sequential filters. Numeric columns (`Churn_Probability`, `Lifetime_Value`, `Average_Order_Value`, `Purchase_Frequency`) are clipped to the selected slider ranges using `.between()`. The `Launch_Date` column is filtered to the selected date range. Categorical columns (`Most_Frequent_Category`, `Region`, `Retention_Strategy`) are then filtered using `.isin()` based on the selected checkbox values. If a checkbox group has nothing selected, that filter is skipped entirely so the app does not return zero rows unexpectedly.
+- **Inputs:** `num_churn_min`, `num_churn_max`, `slider_churn_decrease`, `slider_customer`, `slider_order`, `slider_freq`, `date_range`, `checkbox_group_type`, `checkbox_group_region`, `checkbox_group_strategy`. Note: The default date range view is explicitly set to the most recent quarter in the dataset.
+- **Transformation:** Starts with a copy of the full 10,000-row dataset and applies sequential filters. Numeric columns (`Lifetime_Value`, `Average_Order_Value`, `Purchase_Frequency`) are clipped to the selected slider ranges using `.between()`. `Churn_Probability` is filtered using the `num_churn_min` and `num_churn_max` boundaries, then further reduced (setting `reduced_max` and the `in_reduced_churn_range` column) according to `slider_churn_decrease`. The `Launch_Date` column is filtered to the selected date range. Categorical columns (`Most_Frequent_Category`, `Region`, `Retention_Strategy`) are then filtered using `.isin()` based on the selected checkbox values. If a checkbox group has nothing selected, that filter is skipped entirely so the app does not return zero rows unexpectedly.
 - **Outputs:** `high_churn_risk`, `heatmap`, `customer_df`, `risk_df`, `order_df`, `frequency_df`, `kpi_count`.
 
 ## Section 5: Complexity Enhancement — Reset Button

--- a/src/app.py
+++ b/src/app.py
@@ -310,12 +310,22 @@ def server(input, output, session):
     @reactive.effect
     @reactive.event(input.reset)
     def reset_filters():
-        # Update the slider inputs to defaults
-        ui.update_slider(
-            id="slider_churn",
-            value=[0.0, 1.0],
+        # Update the inputs to defaults
+        ui.update_numeric(
+            id="num_churn_min",
+            value=0.0,
             session=session
-        )    
+        )
+        ui.update_numeric(
+            id="num_churn_max",
+            value=1.0,
+            session=session
+        )
+        ui.update_slider(
+            id="slider_churn_decrease",
+            value=0,
+            session=session
+        )
         ui.update_slider(
             id="slider_customer",
             value=[100, 10000],

--- a/src/app.py
+++ b/src/app.py
@@ -54,12 +54,28 @@ kpi_component = ui.layout_columns(
 )
 
 main_sidebar = ui.sidebar(
-    ui.input_slider(
-        id="slider_churn",
-        label="Churn Rate",
+    ui.input_numeric(
+        id="num_churn_min",
+        label="Churn rate min",
+        value=0.0,
         min=0.0,
         max=1.0,
-        value=[0.0, 1.0],
+        step=0.01,
+    ),
+    ui.input_numeric(
+        id="num_churn_max",
+        label="Churn rate max",
+        value=1.0,
+        min=0.0,
+        max=1.0,
+        step=0.01,
+    ),
+    ui.input_slider(
+        id="slider_churn_decrease",
+        label="Churn rate decrease (%)",
+        min=0,
+        max=100,
+        value=0,
     ),
     ui.input_slider(
         id="slider_customer",

--- a/src/app.py
+++ b/src/app.py
@@ -429,7 +429,12 @@ def server(input, output, session):
     @render_widget
     def high_churn_risk():
         df = filtered_df()
-        churn_min, churn_max = input.slider_churn()
+        churn_min_raw = input.num_churn_min()
+        churn_max_raw = input.num_churn_max()
+        churn_min = min(churn_min_raw, churn_max_raw)
+        churn_max = max(churn_min_raw, churn_max_raw)
+        pct_decrease = input.slider_churn_decrease()
+        reduced_max = churn_max * (1 - pct_decrease / 100)
 
         if df.empty:
             fig = px.scatter(title="No data available for current filters")
@@ -445,7 +450,7 @@ def server(input, output, session):
             hover_data=["Customer_ID", "Region", "Churn_Probability", "Purchase_Frequency"],
         )
         fig.update_layout(
-            title=f"Customers by Lifetime Value and Days Between Purchases, Churn Risk From {churn_min} to {churn_max}",
+            title=f"Customers by Lifetime Value and Days Between Purchases, Churn Risk From {churn_min:0.2f} to {reduced_max:0.2f}",
             xaxis_title="Customer Lifetime Value",
             yaxis_title="Days Between Purchases",
             legend_title="Retention Strategy",

--- a/src/app.py
+++ b/src/app.py
@@ -268,13 +268,25 @@ def server(input, output, session):
     @reactive.calc
     def filtered_df():
         df = sales_df.copy()
-        churn_min, churn_max = input.slider_churn()
+        churn_min_raw = input.num_churn_min()
+        churn_max_raw = input.num_churn_max()
+        churn_min = min(churn_min_raw, churn_max_raw)
+        churn_max = max(churn_min_raw, churn_max_raw)
+        pct_decrease = input.slider_churn_decrease()
+
         clv_min, clv_max = input.slider_customer()
         order_min, order_max = input.slider_order()
         freq_min, freq_max = input.slider_freq()
         date_start, date_end = input.date_range()
 
+        # Math: reduced_max = churn_max * (1 - pct_decrease / 100).
+        reduced_max = churn_max * (1 - pct_decrease / 100)
+
         df = df[df["Churn_Probability"].between(churn_min, churn_max)]
+        if pct_decrease > 0:
+            df = df[df["Churn_Probability"] <= reduced_max]
+            
+        df["in_reduced_churn_range"] = (df["Churn_Probability"] >= churn_min) & (df["Churn_Probability"] <= reduced_max)
         df = df[df["Lifetime_Value"].between(clv_min, clv_max)]
         df = df[df["Average_Order_Value"].between(order_min, order_max)]
         df = df[df["Purchase_Frequency"].between(freq_min, freq_max)]


### PR DESCRIPTION
This PR updates the churn filtering experience as outlined in #98. The previous generic range slider wasn’t flexible enough to let users directly simulate churn reduction targets, so I have rebuilt its logic:

- UI Swaps: Replaced the previous slider_churn range with two independent number inputs for 'Churn rate min' and 'max'.
- Added a distinct "Churn rate decrease (%)" slider beneath it.
- Math Logic: Implemented bounds clamping (so min can never exceed max) and added a backend modifier reduced_max scaling off the % slider.
- Data Hook: Appended an in_reduced_churn_range boolean to filtered_df(), allowing future styling overrides (like Issue #105) to track rows dynamically without destroying base aggregations.
- Stability: Rewired the Reset button to hit these distinct properties cleanly and updated the scatterplot description loop to output the active mathematical bounds (min to reduced_max) dynamically instead of the raw (0 to 1) boundaries.