### PR TITLE
Milestone3/105 churn plot coloring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Replaced the previous churn rate range slider with two independent numerical inputs and a new "Churn rate decrease (%)" slider to directly simulate churn reduction models (Closes #98).
 
+### Changed
+- Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).
+
 ## [0.2.0] - 2026-02-28
 
 ### Added

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -85,9 +85,17 @@ flowchart TD
   I --> O4([risk_df])
   I --> O5([order_df])
   I --> O6([frequency_df])
-  F --> C{{churn_plot_df}}
+  J --> C_df{{churn_plot_df}}
+  K --> C_df
+  A --> C_df
+  B --> C_df
+  C --> C_df
+  D --> C_df
+  E --> C_df
+  G --> C_df
+  H --> C_df
   F -.-> O1([high_churn_risk])
-  C -.-> O1
+  C_df -.-> O1
   F --> O2([heatmap])
   F --> O3
   F --> O4

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -39,7 +39,8 @@ And these are the updated job stories and their progress as of Milestone 2:
 | `date_range`  | Input         | `ui.input_date_range()`    | -                           | #1, #2, #3 |
 | `reset` | Input        | `ui.input_action_button()`   | `num_churn_*`, `slider_*`, `check_box_group_*`, `date_range`  | #1, #2, #3 |
 | `filtered_df` | Reactive calc | `@reactive.calc`        | `num_churn_*`, `slider_*`, `check_box_group_*`, `date_range` | #1, #2, #3 |
-| `high_churn_risk` | Output        | `@render_widget`        | `filtered_df`                | #2         |
+| `churn_plot_df` | Reactive calc | `@reactive.calc` | `num_churn_*`, `slider_*`, `check_box_group_*`, `date_range` | #2 |
+| `high_churn_risk` | Output        | `@render_widget`        | `filtered_df`, `churn_plot_df`                | #2         |
 | `row_dropdown`    | Input         | `ui.input_select()`     | —                            | #1         |
 | `customer_df` | Output        | `@render.data_frame`    | `filtered_df`,`row_dropdown` | #1         |
 | `risk_df`     | Output        | `@render.data_frame`    | `filtered_df`,`row_dropdown` | #1         |
@@ -84,7 +85,9 @@ flowchart TD
   I --> O4([risk_df])
   I --> O5([order_df])
   I --> O6([frequency_df])
-  F --> O1([high_churn_risk])
+  F --> C{{churn_plot_df}}
+  F -.-> O1([high_churn_risk])
+  C -.-> O1
   F --> O2([heatmap])
   F --> O3
   F --> O4
@@ -100,7 +103,13 @@ flowchart TD
 
 - **Inputs:** `num_churn_min`, `num_churn_max`, `slider_churn_decrease`, `slider_customer`, `slider_order`, `slider_freq`, `date_range`, `checkbox_group_type`, `checkbox_group_region`, `checkbox_group_strategy`. Note: The default date range view is explicitly set to the most recent quarter in the dataset.
 - **Transformation:** Starts with a copy of the full 10,000-row dataset and applies sequential filters. Numeric columns (`Lifetime_Value`, `Average_Order_Value`, `Purchase_Frequency`) are clipped to the selected slider ranges using `.between()`. `Churn_Probability` is filtered using the `num_churn_min` and `num_churn_max` boundaries, then further reduced (setting `reduced_max` and the `in_reduced_churn_range` column) according to `slider_churn_decrease`. The `Launch_Date` column is filtered to the selected date range. Categorical columns (`Most_Frequent_Category`, `Region`, `Retention_Strategy`) are then filtered using `.isin()` based on the selected checkbox values. If a checkbox group has nothing selected, that filter is skipped entirely so the app does not return zero rows unexpectedly.
-- **Outputs:** `high_churn_risk`, `heatmap`, `customer_df`, `risk_df`, `order_df`, `frequency_df`, `kpi_count`.
+- **Outputs:** `high_churn_risk` (if `slider_churn_decrease` is 0), `heatmap`, `customer_df`, `risk_df`, `order_df`, `frequency_df`, `kpi_count`.
+
+### `churn_plot_df`
+
+- **Inputs:** Operates utilizing the same core logic parameters as `filtered_df` (tracking all global sliders and checkboxes). 
+- **Transformation:** Bypasses the strict `reduced_max` threshold cull triggered when the `slider_churn_decrease` goes above 0. Evaluates that top percentage grouping with a mapping boolean column: `in_reduced_churn_range`.
+- **Outputs:** `high_churn_risk` (Active selectively when `slider_churn_decrease` > 0 to plot the chopped-off metric bands concurrently).
 
 ## Section 5: Complexity Enhancement — Reset Button
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ plotly==6.0.1
 pydantic==2.11.7
 quarto==0.1.0
 requests==2.32.4
-shiny==1.4.0
+shiny>=1.5.1
 tabulate==0.9.0
 tinycss2==1.4.0
 vegafusion==2.0.2

--- a/src/app.py
+++ b/src/app.py
@@ -266,6 +266,44 @@ def server(input, output, session):
         yield ai_filtered_df().to_csv(index=False)
 
     @reactive.calc
+    def churn_plot_df():
+        df = sales_df.copy()
+        churn_min_raw = input.num_churn_min()
+        churn_max_raw = input.num_churn_max()
+        churn_min = min(churn_min_raw, churn_max_raw)
+        churn_max = max(churn_min_raw, churn_max_raw)
+        pct_decrease = input.slider_churn_decrease()
+
+        clv_min, clv_max = input.slider_customer()
+        order_min, order_max = input.slider_order()
+        freq_min, freq_max = input.slider_freq()
+        date_start, date_end = input.date_range()
+
+        reduced_max = churn_max * (1 - pct_decrease / 100)
+
+        df = df[df["Churn_Probability"].between(churn_min, churn_max)]
+            
+        df["in_reduced_churn_range"] = (df["Churn_Probability"] >= churn_min) & (df["Churn_Probability"] <= reduced_max)
+        
+        df = df[df["Lifetime_Value"].between(clv_min, clv_max)]
+        df = df[df["Average_Order_Value"].between(order_min, order_max)]
+        df = df[df["Purchase_Frequency"].between(freq_min, freq_max)]
+        df = df[df["Launch_Date"].between(pd.Timestamp(date_start),pd.Timestamp(date_end))]
+
+        types = input.checkbox_group_type() 
+        regions = input.checkbox_group_region() 
+        strategies = input.checkbox_group_strategy() 
+
+        if types:
+            df = df[df["Most_Frequent_Category"].isin(types)]
+        if regions:
+            df = df[df["Region"].isin(regions)]
+        if strategies:
+            df = df[df["Retention_Strategy"].isin(strategies)]
+
+        return df
+
+    @reactive.calc
     def filtered_df():
         df = sales_df.copy()
         churn_min_raw = input.num_churn_min()

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,6 @@
 from shiny import App, render, ui, reactive
 from shiny.types import ImgData
 import plotly.express as px
-from ridgeplot import ridgeplot
 import seaborn as sns
 from shinywidgets import render_plotly, render_widget, output_widget
 import pandas as pd

--- a/src/app.py
+++ b/src/app.py
@@ -466,23 +466,32 @@ def server(input, output, session):
 
     @render_widget
     def high_churn_risk():
-        df = filtered_df()
+        pct_decrease = input.slider_churn_decrease()
+        df = churn_plot_df() if pct_decrease > 0 else filtered_df()
+        
         churn_min_raw = input.num_churn_min()
         churn_max_raw = input.num_churn_max()
         churn_min = min(churn_min_raw, churn_max_raw)
         churn_max = max(churn_min_raw, churn_max_raw)
-        pct_decrease = input.slider_churn_decrease()
         reduced_max = churn_max * (1 - pct_decrease / 100)
 
         if df.empty:
             fig = px.scatter(title="No data available for current filters")
             return fig
 
+        if pct_decrease > 0:
+            df["status"] = df["in_reduced_churn_range"].map({True: "In Range", False: "Excluded"})
+            color_col = "status"
+            legend_title = "Within Reduced Range"
+        else:
+            color_col = "Retention_Strategy"
+            legend_title = "Retention Strategy"
+
         fig = px.scatter(
             df,
             x="Lifetime_Value",
             y="Time_Between_Purchases",
-            color="Retention_Strategy",
+            color=color_col,
             size="Churn_Probability",
             size_max=18,
             hover_data=["Customer_ID", "Region", "Churn_Probability", "Purchase_Frequency"],
@@ -491,7 +500,7 @@ def server(input, output, session):
             title=f"Customers by Lifetime Value and Days Between Purchases, Churn Risk From {churn_min:0.2f} to {reduced_max:0.2f}",
             xaxis_title="Customer Lifetime Value",
             yaxis_title="Days Between Purchases",
-            legend_title="Retention Strategy",
+            legend_title=legend_title,
         )
         return fig
     


### PR DESCRIPTION
This PR completes issue #105, which builds seamlessly on top of our new churn filtering sliders from #98.

The scatterplot maps that interaction actively to maintain a global visualization scale while still identifying target groupings.

- New Reactive View (churn_plot_df): Added a middleman dataframe hook built precisely for the Churn Risk Plot. It reads all global filters just like before, but instead of cutting off data when the % decrease slider triggers, it maps that "cutoff" threshold to a boolean status column.
- Dynamic Scatterplot Logic (high_churn_risk): When the decrease slider is 0%, the plot behaves normally (colored by Retention_Strategy). If you slide the decrease above 0%, the plot dynamically swaps datasets to churn_plot_df, recoloring points to showcase "In Range" vs "Excluded" status based on your new threshold!
- Documentation & Cleanup: Logged the components diagram map updates spanning the UI to the backend calculation changes for reports/m2_spec.md alongside appending an entry to the CHANGELOG.md.
- cleaned up a dead ridgeplot import string from src/app.py.