### PR TITLE
Add manual AI integration testing protocols 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default filter view set to most recent quarter; reset button restores to this default (Issue #104).
 - Replaced the previous churn rate range slider with two independent numerical inputs and a new "Churn rate decrease (%)" slider to directly simulate churn reduction models (Closes #98).
 - Added a quartile box plot alongside the scatter plot in the Churn Risk Plot tab to show churn probability distributions across retention strategies (Issue #99).
+- Added `docs/AI_INTEGRATION_TESTING.md` containing manual AI checklist evaluation protocols matching Issue #97 definitions.
 
 ### Changed
 - Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).

--- a/docs/AI_INTEGRATION_TESTING.md
+++ b/docs/AI_INTEGRATION_TESTING.md
@@ -1,0 +1,44 @@
+# AI Integration Testing Document (M3)
+
+This document outlines the testing protocols for the AI-assisted filtering tab introduced in Milestone 3, ensuring all LLM boundaries operate seamlessly with legacy components alongside edge-casing failure states. 
+
+**Note on Models:** 
+Because output interpretation varies largely between free-tier models (like `gpt-4.1-mini`) and paid tiers (like `claude-sonnet-4-0`), ensure you accurately record the active model mapping the test to help narrow down interpretation bugs.
+
+---
+
+## Testing Checklist
+
+### 1. QueryChat Interaction
+- [ ] **Prompt Logging:** Test the chat interface by submitting natural language queries.
+- [ ] **DF Target Logic:** Ensure the AI comprehends bounds (e.g. "Customers with Lifetime Value over 5000") and executes filter modifications across the `ai_data_table` output.
+
+### 2. AI Filtered Data Display
+- [ ] **Render:** Validate the right-hand Datagrid successfully populates the subset parsed by the LLM without throwing index errors.
+- [ ] **Column Parity:** Ensure the table still contains all primary categorical markers and expected integers matching the baseline data.
+
+### 3. File Download 
+- [ ] **Export Integrity:** Use the Download button over the AI filters. Open the `.csv` and confirm the row count explicitly matches the exact parsed volume from the datatable above it rather than the full, unfiltered 10,000 row raw set.
+
+### 4. Global Override Mapping ("Use AI filtered data for dashboard")
+- [ ] **Checkbox State:** Toggle the AI override boundary checkbox on the central app logic.
+- [ ] **KPI Recalibration:** Verify that checking the box aggressively hijacks the global application dataset binding (`kpi_count`, heatmap aggregates) and ignores sidebar inputs. 
+- [ ] **Undo Function:** Verify that unchecking the box reverts the system back to normal sidebar manual overrides flawlessly without needing a browser refresh.
+
+### 5. AI Empty States (Edge Cases)
+- [ ] **Null Filters:** Ask the LLM to filter impossible parameters (e.g. "Find me customers with over $900,000,000 LTV"). Verify the AI successfully renders a 0-row empty dataframe instead of crashing the core `app.py` process.
+
+### 6. Automated Evals (Future Work)
+- [ ] *Optional:* If `inspect_ai` framework gets initialized, build out Python assertions tracing conversational memory mappings directly to the model container endpoint as documented in the course's automated eval syllabus block.
+
+---
+
+## Test Record
+
+*Copy and paste this section per test run.*
+
+**Date:** YYYY-MM-DD
+**Model Selected:** `e.g. claude-sonnet-4-0`
+**Result:** [ PASS / FAIL / BUG ]
+**Tester Notes:**
+> *Record any crashes or specific logic the LLM struggled to filter correctly...*


### PR DESCRIPTION
Resolving issue #97 by adding a formal, manual evaluation framework required for our AI LLM dependencies introduced in M3.

Since we are relying on LLM free model, model interpretation behavior can swing dramatically. To ensure our LLM connections don't break our base-level reactivity, I drafted a complete testing protocol checklist that documents exactly how a human tester should deliberately try to break our new LLM tools.

Key Additions ==> docs/AI_INTEGRATION_TESTING.md
- Created the core testing documentation. It holds strict guidelines validating QueryChat logic parsing, the resulting dynamic Datagrid output boundaries, overriding dashboard KPIs with the "Use AI filtered data" checkbox, and aggressively crashing the system using impossible edge-cases inputs (e.g. asking for metrics that don't exist).
- Added a blank testing template table at the bottom to easily log runs alongside the baseline Model selected.
- Appended CHANGELOG.md to reference the new protocol directory.
