### PR TITLE
Configure KPI comparative deltas to track active churn simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default filter view set to most recent quarter; reset button restores to this default (Issue #104).
 - Replaced the previous churn rate range slider with two independent numerical inputs and a new "Churn rate decrease (%)" slider to directly simulate churn reduction models (Closes #98).
 - Added a quartile box plot alongside the scatter plot in the Churn Risk Plot tab to show churn probability distributions across retention strategies (Issue #99).
+- Added comparison subtext to the main KPIs indicating the metric delta (amount and direction) when the churn decrease slider is active (Closes #103).
 
 ### Changed
 - Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -119,7 +119,7 @@ flowchart TD
 
 - **Inputs:** Operates utilizing the same core logic parameters as `filtered_df` (tracking all global sliders and checkboxes). 
 - **Transformation:** Bypasses the strict `reduced_max` threshold cull triggered when the `slider_churn_decrease` goes above 0. Evaluates that top percentage grouping with a mapping boolean column: `in_reduced_churn_range`.
-- **Outputs:** `high_churn_risk` (Active selectively when `slider_churn_decrease` > 0 to plot the chopped-off metric bands concurrently).
+- **Outputs:** `high_churn_risk` (Active selectively when `slider_churn_decrease` > 0 to plot the chopped-off metric bands concurrently) and baseline mapping computations for main KPI output strings (`kpi_lifetime`, `kpi_churn`, `kpi_risk`, `kpi_days`) tracking comparative change deltas.
 
 ## Section 5: Complexity Enhancement — Reset Button
 

--- a/src/app.py
+++ b/src/app.py
@@ -442,30 +442,78 @@ def server(input, output, session):
     @render.ui
     def kpi_lifetime():
         df = filtered_df()
+        pct_decrease = input.slider_churn_decrease()
         if df.empty:
             return "—"
-        return f"${df['Lifetime_Value'].mean():,.2f}"
+        val = df['Lifetime_Value'].mean()
+        val_str = f"${val:,.2f}"
+        
+        if pct_decrease > 0:
+            df_base = churn_plot_df()
+            if not df_base.empty:
+                base_val = df_base['Lifetime_Value'].mean()
+                delta = val - base_val
+                sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                subtext = f"{sign}${abs(delta):,.2f}"
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+        return val_str
 
     @render.ui
     def kpi_churn():
         df = filtered_df()
+        pct_decrease = input.slider_churn_decrease()
         if df.empty:
             return "—"
-        return f"{df['Churn_Probability'].mean():.1%}"
+        val = df['Churn_Probability'].mean()
+        val_str = f"{val:.1%}"
+        
+        if pct_decrease > 0:
+            df_base = churn_plot_df()
+            if not df_base.empty:
+                base_val = df_base['Churn_Probability'].mean()
+                delta = val - base_val
+                sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                subtext = f"{sign}{abs(delta):.1%}"
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+        return val_str
 
     @render.ui
     def kpi_risk():
         df = filtered_df()
+        pct_decrease = input.slider_churn_decrease()
         if df.empty:
             return "—"
-        return f"${df['risk_value'].mean():,.2f}"
+        val = df['risk_value'].mean()
+        val_str = f"${val:,.2f}"
+        
+        if pct_decrease > 0:
+            df_base = churn_plot_df()
+            if not df_base.empty:
+                base_val = df_base['risk_value'].mean()
+                delta = val - base_val
+                sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                subtext = f"{sign}${abs(delta):,.2f}"
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+        return val_str
 
     @render.ui
     def kpi_days():
         df = filtered_df()
+        pct_decrease = input.slider_churn_decrease()
         if df.empty:
             return "—"
-        return f"{df['Time_Between_Purchases'].mean():,.2f} days"
+        val = df['Time_Between_Purchases'].mean()
+        val_str = f"{val:,.2f} days"
+        
+        if pct_decrease > 0:
+            df_base = churn_plot_df()
+            if not df_base.empty:
+                base_val = df_base['Time_Between_Purchases'].mean()
+                delta = val - base_val
+                sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                subtext = f"{sign}{abs(delta):,.2f} days"
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+        return val_str
 
     @render.data_frame
     def customer_df():

--- a/src/app.py
+++ b/src/app.py
@@ -45,13 +45,13 @@ qc = querychat.QueryChat(
 
 kpi_component = ui.layout_columns(
     ui.layout_columns(
-        ui.value_box("Avg Lifetime Value (Filtered Base)", ui.output_text("kpi_lifetime")),
-        ui.value_box("Avg Value-At-Risk (Filtered Base)", ui.output_text("kpi_risk")),
+        ui.value_box("Avg Lifetime Value (Filtered Base)", ui.output_ui("kpi_lifetime")),
+        ui.value_box("Avg Value-At-Risk (Filtered Base)", ui.output_ui("kpi_risk")),
         col_widths=(12, 12)
     ),
     ui.layout_columns(
-        ui.value_box("Avg Churn (Filtered Base)", ui.output_text("kpi_churn")),
-        ui.value_box("Avg Days Between Purchases (Filtered Base)", ui.output_text("kpi_days")),
+        ui.value_box("Avg Churn (Filtered Base)", ui.output_ui("kpi_churn")),
+        ui.value_box("Avg Days Between Purchases (Filtered Base)", ui.output_ui("kpi_days")),
         col_widths=(12, 12)
     ),
     ui.layout_columns(
@@ -439,28 +439,28 @@ def server(input, output, session):
             session=session
         )
 
-    @render.text
+    @render.ui
     def kpi_lifetime():
         df = filtered_df()
         if df.empty:
             return "—"
         return f"${df['Lifetime_Value'].mean():,.2f}"
 
-    @render.text
+    @render.ui
     def kpi_churn():
         df = filtered_df()
         if df.empty:
             return "—"
         return f"{df['Churn_Probability'].mean():.1%}"
 
-    @render.text
+    @render.ui
     def kpi_risk():
         df = filtered_df()
         if df.empty:
             return "—"
         return f"${df['risk_value'].mean():,.2f}"
 
-    @render.text
+    @render.ui
     def kpi_days():
         df = filtered_df()
         if df.empty:


### PR DESCRIPTION
This PR is tackling #103 adds a quick quality-of-life feature! Before, when you used the "Churn rate decrease (%)" slider, the main KPI numbers would change but you couldn't tell exactly how much they changed compared to the original filtered data.

Now, whenever that slider is active (above 0%), the four main KPIs will automatically calculate the difference from the baseline and show it as a small "delta" subtext right below the main number (e.g. -$12.00 or +0.42 days).

- Swapped the 4 main KPIs to use UI outputs so they can render the smaller subtext HTML below the main string.
- Added math logic to calculate the difference using churn_plot_df as the true baseline.
- Skipped adding subtext to the "Count of Datapoints" box as requested.
- Added quick notes to the spec docs and CHANGELOG.md.