### PR TITLE
Fix KPI layout and add low sample warning for datapoint count

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -44,17 +44,12 @@ qc = querychat.QueryChat(
 )
 
 kpi_component = ui.layout_columns(
-    ui.layout_columns(
-        ui.value_box("Average Lifetime Value", ui.output_text("kpi_lifetime")),
-        ui.value_box("Average Churn Rate", ui.output_text("kpi_churn")),
-        ui.value_box("Average Value-At-Risk", ui.output_text("kpi_risk")),
-        ui.value_box("Average Days Per Purchase", ui.output_text("kpi_days")),
-        col_widths = (6,6,6,6)
-    ),
+    ui.value_box("Average Lifetime Value", ui.output_text("kpi_lifetime")),
+    ui.value_box("Average Churn Rate", ui.output_text("kpi_churn")),
     ui.value_box("Count of Datapoints", ui.output_text("kpi_count")),
-    col_widths = (8,4), # 12 part ratio
-    # row_heights= (1,2), # direct ratio
-    fill=False
+    ui.value_box("Average Value-At-Risk", ui.output_text("kpi_risk")),
+    ui.value_box("Average Days Per Purchase", ui.output_text("kpi_days")),
+    col_widths=(4, 4, 4, 6, 6)
 )
 
 main_sidebar = ui.sidebar(
@@ -590,7 +585,10 @@ def server(input, output, session):
     @render.text
     def kpi_count():
         df = dashboard_df()
-        return f"{len(df):,}"
+        count = len(df)
+        if count < 50:
+            return f"{count:,} ⚠️ Low sample"
+        return f"{count:,}"
 
 
 # Create app


### PR DESCRIPTION
Resolve issue #100:

- Adjusted the KPI layout so the “Count of Datapoints” box is no longer oversized.
- Added a warning indicator when the filtered dataset contains fewer than 50 observations to signal potential reliability issues.
<img width="1440" height="774" alt="Screenshot 2026-03-07 at 20 18 33" src="https://github.com/user-attachments/assets/a2e7607e-1d23-49b8-b56d-458a0a928d96" />
