### PR TITLE
Add KPI delta colour coding for comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).
+- Added red/green color coding to the KPI comparison delta subtext to quickly indicate positive or negative performance changes (Closes #129).
 
 ### Changed
 - Clarified KPI labels and chart titles to reflect filtered segments and units (Issue #102).

--- a/src/app.py
+++ b/src/app.py
@@ -454,8 +454,9 @@ def server(input, output, session):
                 base_val = df_base['Lifetime_Value'].mean()
                 delta = val - base_val
                 sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                color = "green" if delta > 0 else "red" if delta < 0 else "inherit"
                 subtext = f"{sign}${abs(delta):,.2f}"
-                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8; color: {color};'>{subtext}</div>")
         return val_str
 
     @render.ui
@@ -473,8 +474,9 @@ def server(input, output, session):
                 base_val = df_base['Churn_Probability'].mean()
                 delta = val - base_val
                 sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                color = "red" if delta > 0 else "green" if delta < 0 else "inherit"
                 subtext = f"{sign}{abs(delta):.1%}"
-                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8; color: {color};'>{subtext}</div>")
         return val_str
 
     @render.ui

--- a/src/app.py
+++ b/src/app.py
@@ -494,8 +494,9 @@ def server(input, output, session):
                 base_val = df_base['risk_value'].mean()
                 delta = val - base_val
                 sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                color = "red" if delta > 0 else "green" if delta < 0 else "inherit"
                 subtext = f"{sign}${abs(delta):,.2f}"
-                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8; color: {color};'>{subtext}</div>")
         return val_str
 
     @render.ui
@@ -513,8 +514,9 @@ def server(input, output, session):
                 base_val = df_base['Time_Between_Purchases'].mean()
                 delta = val - base_val
                 sign = "+" if delta > 0 else "−" if delta < 0 else ""
+                color = "red" if delta > 0 else "green" if delta < 0 else "inherit"
                 subtext = f"{sign}{abs(delta):,.2f} days"
-                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
+                return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8; color: {color};'>{subtext}</div>")
         return val_str
 
     @render.data_frame


### PR DESCRIPTION
When the churn decrease slider is active, the delta subtext is coloured: green for favourable changes (LTV increase, Churn/Risk/Days decrease), red for unfavourable changes, and inherit when delta is zero.

Closes #129 