### PR TITLE
Add dynamic decision-making cues module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).
+- Added direct decision-making cues analyzing the filtered dataset to offer dynamic business insights natively beneath the KPI block (Closes #130).
 
 ### Changed
 - Clarified KPI labels and chart titles to reflect filtered segments and units (Issue #102).

--- a/src/app.py
+++ b/src/app.py
@@ -286,6 +286,11 @@ app_ui = ui.page_navbar(
             .nav-tabs .nav-link { font-size: 1.05em; }
         """),
         kpi_component,
+        ui.card(
+            ui.card_header("💡 Actionable Insights & Next Steps", style="font-weight: bold; font-size: 1.1em; background-color: #f8f9fa; padding: 0.5rem 1rem;"),
+            ui.output_ui("decision_cues"),
+            style="margin-bottom: 20px; border-left: 4px solid #007bc2;"
+        )
     ),
     id="top_navbar",
     theme=ui.Theme("lumen")
@@ -549,6 +554,38 @@ def server(input, output, session):
                 subtext = f"{sign}{abs(delta):,.2f} days"
                 return ui.HTML(f"<div>{val_str}</div><div style='font-size: 0.6em; opacity: 0.8;'>{subtext}</div>")
         return val_str
+
+    @render.ui
+    def decision_cues():
+        df = filtered_df()
+        if df.empty:
+            return ui.markdown("No data available to generate insights.")
+        
+        cues = []
+        
+        # Cue 1: Region with highest churn
+        if "Region" in df.columns and "Churn_Probability" in df.columns:
+            region_churn = df.groupby("Region")["Churn_Probability"].mean()
+            if not region_churn.empty:
+                high_risk = region_churn.idxmax()
+                val = region_churn.max()
+                if val > 0.4:
+                    cues.append(f"**Focus on {high_risk}**: This region has the highest average churn risk ({val:.1%}). Consider localized retention campaigns.")
+                else:
+                    cues.append(f"**Stable Regions**: Across all regions, churn remains manageable (highest: {high_risk} at {val:.1%}).")
+
+        # Cue 2: Retention strategy with highest CLV
+        if "Retention_Strategy" in df.columns and "Lifetime_Value" in df.columns:
+            strat_ltv = df.groupby("Retention_Strategy")["Lifetime_Value"].mean()
+            if not strat_ltv.empty:
+                best_strat = strat_ltv.idxmax()
+                cues.append(f"**Scale {best_strat}**: This retention strategy is currently driving the highest Average Lifetime Value (${strat_ltv.max():,.0f}).")
+            
+        if not cues:
+            return ui.markdown("Data distribution appears stable. No immediate critical interventions flagged.")
+            
+        markup = "".join([f"- {cue}\n" for cue in cues])
+        return ui.markdown(markup)
 
     @render.data_frame
     def customer_df():


### PR DESCRIPTION
Following up on the UX feedback regarding decision-making context (#130), this PR adds an insights module below the KPIs.

- Dynamic cues card: New `ui.card()` below the KPI grid with " Actionable Insights & Next Steps"
- Backend logic: `decision_cues` uses `filtered_df()` to output 2 cues:
  1. Region with highest churn -> "Focus on X" or "Stable Regions" (if churn < 40%)
  2. Retention strategy with highest LTV -> "Scale X"
- Edge handling: Empty or uniform data -> "No data available" / "Data distribution appears stable"