### PR TITLE
Add dynamic Scatter Plot & Heatmap visualizations to AI Insights tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the previous churn rate range slider with two independent numerical inputs and a new "Churn rate decrease (%)" slider to directly simulate churn reduction models (Closes #98).
 - Added a quartile box plot alongside the scatter plot in the Churn Risk Plot tab to show churn probability distributions across retention strategies (Issue #99).
 - Added comparison subtext to the main KPIs indicating the metric delta (amount and direction) when the churn decrease slider is active (Closes #103).
+- Added scatter plot in AI Insights tab using querychat filtered dataframe (Closes #135).
 
 ### Changed
 - Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a quartile box plot alongside the scatter plot in the Churn Risk Plot tab to show churn probability distributions across retention strategies (Issue #99).
 - Added comparison subtext to the main KPIs indicating the metric delta (amount and direction) when the churn decrease slider is active (Closes #103).
 - Added scatter plot in AI Insights tab using querychat filtered dataframe (Closes #135).
+- Added heatmap (Season × Category, mean LTV) in AI Insights tab using querychat filtered dataframe (Closes #137).
 
 ### Changed
 - Reworked the Churn Risk Plot to color points by their status ("In Range" vs "Excluded") whenever the churn decrease slider is active, making it easier to see which customers are impacted by the simulated churn reduction (Closes #105).

--- a/src/app.py
+++ b/src/app.py
@@ -339,12 +339,21 @@ def server(input, output, session):
         if df is None or df.empty:
             return px.scatter(title="No data available for current filters")
 
+        req_cols = ["Lifetime_Value", "Time_Between_Purchases"]
+        missing_cols = [col for col in req_cols if col not in df.columns]
+        if missing_cols:
+            return px.scatter(title=f"Missing expected columns from AI filter: {', '.join(missing_cols)}")
+
+        hover_cols = ["Customer_ID", "Region", "Churn_Probability", "Purchase_Frequency"]
+        actual_hover = [c for c in hover_cols if c in df.columns]
+
         fig = px.scatter(
             df,
-            x="Lifetime_Value" if "Lifetime_Value" in df.columns else None,
-            y="Time_Between_Purchases" if "Time_Between_Purchases" in df.columns else None,
+            x="Lifetime_Value",
+            y="Time_Between_Purchases",
             color="Retention_Strategy" if "Retention_Strategy" in df.columns else None,
             size="Churn_Probability" if "Churn_Probability" in df.columns else None,
+            hover_data=actual_hover,
             size_max=18
         )
         fig.update_layout(

--- a/src/app.py
+++ b/src/app.py
@@ -372,6 +372,17 @@ def server(input, output, session):
         df = ai_filtered_df()
         if df is None or df.empty:
             return px.scatter(title="No data available for current filters")
+        req_cols = ["Season", "Most_Frequent_Category", "Lifetime_Value"]
+        missing_cols = [c for c in req_cols if c not in df.columns]
+        if missing_cols:
+            return px.scatter(
+                title=f"Missing expected columns from AI filter: {', '.join(missing_cols)}"
+            )
+        plot_data = (
+            df.groupby(["Season", "Most_Frequent_Category"])["Lifetime_Value"]
+            .mean()
+            .reset_index()
+        )
         return px.scatter(title="Placeholder ai_tab_heatmap")
 
     @reactive.calc

--- a/src/app.py
+++ b/src/app.py
@@ -332,6 +332,15 @@ def server(input, output, session):
     def download_ai_filtered():
         yield ai_filtered_df().to_csv(index=False)
 
+    @render_widget
+    def ai_tab_scatter():
+        df = ai_filtered_df()
+        
+        if df is None or df.empty:
+            return px.scatter(title="No data available for current filters")
+
+        return px.scatter(title="Placeholder for scatter plot")
+
     @reactive.calc
     def churn_plot_df():
         df = sales_df.copy()

--- a/src/app.py
+++ b/src/app.py
@@ -267,7 +267,11 @@ panel_ai = ui.nav_panel("AI Insights",
                 output_widget("ai_tab_scatter"),
                 full_screen=True
             ),
-            col_widths=(12, 12)
+            ui.card(
+                output_widget("ai_tab_heatmap"),
+                full_screen=True
+            ),
+            col_widths=(12, 12, 12)
         )
     )
 )

--- a/src/app.py
+++ b/src/app.py
@@ -339,7 +339,20 @@ def server(input, output, session):
         if df is None or df.empty:
             return px.scatter(title="No data available for current filters")
 
-        return px.scatter(title="Placeholder for scatter plot")
+        fig = px.scatter(
+            df,
+            x="Lifetime_Value" if "Lifetime_Value" in df.columns else None,
+            y="Time_Between_Purchases" if "Time_Between_Purchases" in df.columns else None,
+            color="Retention_Strategy" if "Retention_Strategy" in df.columns else None,
+            size="Churn_Probability" if "Churn_Probability" in df.columns else None,
+            size_max=18
+        )
+        fig.update_layout(
+            title="AI-filtered: Customers by LTV and Days Between Purchases",
+            xaxis_title="Customer Lifetime Value ($)",
+            yaxis_title="Days Between Purchases"
+        )
+        return fig
 
     @reactive.calc
     def churn_plot_df():

--- a/src/app.py
+++ b/src/app.py
@@ -367,6 +367,13 @@ def server(input, output, session):
         )
         return fig
 
+    @render_widget
+    def ai_tab_heatmap():
+        df = ai_filtered_df()
+        if df is None or df.empty:
+            return px.scatter(title="No data available for current filters")
+        return px.scatter(title="Placeholder ai_tab_heatmap")
+
     @reactive.calc
     def churn_plot_df():
         df = sales_df.copy()

--- a/src/app.py
+++ b/src/app.py
@@ -262,7 +262,12 @@ panel_ai = ui.nav_panel("AI Insights",
             ui.card(
                 ui.card_header("AI Filtered Data"),
                 ui.output_data_frame("ai_data_table")
-            )
+            ),
+            ui.card(
+                output_widget("ai_tab_scatter"),
+                full_screen=True
+            ),
+            col_widths=(12, 12)
         )
     )
 )

--- a/src/app.py
+++ b/src/app.py
@@ -383,7 +383,17 @@ def server(input, output, session):
             .mean()
             .reset_index()
         )
-        return px.scatter(title="Placeholder ai_tab_heatmap")
+        fig = px.density_heatmap(
+            plot_data,
+            x="Season",
+            y="Most_Frequent_Category",
+            z="Lifetime_Value",
+            title="AI-filtered: Avg LTV by Season vs. Category",
+            labels={"Lifetime_Value": "Avg LTV ($)", "Most_Frequent_Category": "Product Type"},
+            color_continuous_scale="Viridis",
+            text_auto=True,
+        )
+        return fig
 
     @reactive.calc
     def churn_plot_df():


### PR DESCRIPTION
#135 and #137 completed. 

Have added two new Plotly charts that hook directly into the ai_filtered_df() output:
- Scatter Plot (#135): Compares LTV and Days Between Purchases, colored by strategy and sized by churn probability.
- Heatmap (#137): Breaks down the average LTV by Season and Product Category.

Note: Since the LLM might output a Dataframe missing the specific columns these charts need, I added some check logic before rendering. If the required columns are missing, or if the dataframe is empty, the UI will safely display a "Missing Columns" or "No Data" placeholder title instead of crashing the app! Everything's been added to the CHANGELOG