### PR TITLE
Remove KPIs when AI Insights tab is active (#175)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -307,12 +307,7 @@ app_ui = ui.page_navbar(
     sidebar=main_sidebar,
     header=ui.TagList(
         ui.markdown("#### Data-driven customer retention and churn analysis."),
-        kpi_component,
-        ui.card(
-            ui.card_header("💡 Actionable Insights & Next Steps", style="font-weight: bold; font-size: 1.1em; background-color: #f8f9fa; padding: 0.5rem 1rem;"),
-            ui.output_ui("decision_cues"),
-            style="margin-bottom: 20px; border-left: 4px solid #007bc2;"
-        )
+        ui.output_ui("conditional_kpis")
     ),
     id="top_navbar",
     theme=ui.Theme("lumen")
@@ -708,6 +703,23 @@ def server(input, output, session):
             
         markup = "".join([f"- {cue}\n" for cue in cues])
         return ui.markdown(markup)
+    
+    @render.ui
+    def conditional_kpis():
+        if input.top_navbar() == "AI Insights":
+            return None
+
+        return ui.TagList(
+            kpi_component,
+            ui.card(
+                ui.card_header(
+                    "💡 Actionable Insights & Next Steps",
+                    style="font-weight: bold; font-size: 1.1em; background-color: #f8f9fa; padding: 0.5rem 1rem;"
+                ),
+                ui.output_ui("decision_cues"),
+                style="margin-bottom: 20px; border-left: 4px solid #007bc2;"
+            )
+        )
 
     @render.data_frame
     def customer_df():


### PR DESCRIPTION
Resolve issue #175 

- KPIs appear normally on the Advanced Figures tab
- KPIs are hidden on the AI Insights tab
- The AI Insights page now focuses only on AI-driven analysis and outputs

<img width="1440" height="787" alt="Screenshot 2026-03-10 at 23 00 00" src="https://github.com/user-attachments/assets/c546050e-55b9-4ccc-85a2-6d9c71e08d07" />
