### PR TITLE
Milestone4/querychat customization

### DIFF
--- a/docs/AI_INTEGRATION_TESTING.md
+++ b/docs/AI_INTEGRATION_TESTING.md
@@ -1,6 +1,58 @@
-# AI Integration Testing Document (M3)
+# AI Integration Document (M3 + M4)
 
-This document outlines the testing protocols for the AI-assisted filtering tab introduced in Milestone 3, ensuring all LLM boundaries operate seamlessly with legacy components alongside edge-casing failure states. 
+This document covers the AI-assisted filtering tab introduced in M3 and the querychat customizations added in M4 (Option A).
+
+---
+
+## M4 Option A: Querychat Customization
+
+We chose Option A (Querychat Customization) over the other three options because we already had a working querychat integration from M3 and wanted to go deeper on making the AI more context-aware and controllable, rather than adding a separate logging backend or knowledge base.
+
+### What we changed
+
+**1. System prompt — `extra_instructions`**
+
+The M3 `data_description` only listed 5 of the 16 dataset columns, had no business framing, and didn't mention `risk_value` at all (even though it's a key derived column in the dashboard). We added `SALESCOPE_EXTRA_INSTRUCTIONS` in `src/app.py` that gives the model:
+
+- A definition of `risk_value = Lifetime_Value × Churn_Probability` as the primary intervention metric
+- Rough churn risk thresholds (>0.7 = high)
+- Instructions to frame answers in business terms (revenue at risk, not just probability values)
+- The full column list so it stops hallucinating on columns like `Preferred_Purchase_Times`
+
+Experiments in `notebooks/querychat_customization.ipynb` show the enhanced prompt produces more actionable, business-framed answers with consistent churn threshold language.
+
+**2. `on_tool_request` hook**
+
+Added `_handle_tool_request` in the server function (registered via `qc_vals.client.on_tool_request`). It:
+- Logs every tool call (tool name + first 80 chars of SQL) to the console
+- Raises `ToolRejectError` when a query doesn't match the current scope mode
+
+The `ToolRejectError` propagates back to the model as a tool failure message, so the model tells the user it can't answer rather than silently failing or crashing.
+
+**3. Analysis Scope dropdown (user-facing control)**
+
+Added `ui.input_select("ai_scope_mode", ...)` to the AI Insights panel with three options:
+- **Full Analysis** — no restrictions, same as M3
+- **Churn Focus Only** — blocks SQL that doesn't reference churn/retention columns
+- **Revenue & LTV Focus Only** — blocks SQL that doesn't reference LTV/order value columns
+
+The scope is stored in a `_scope` dict that gets updated by a `@reactive.effect` whenever the dropdown changes. The `on_tool_request` callback reads from this dict directly, which bridges Shiny's reactive world with chatlas's synchronous callback.
+
+### Design decisions and alternatives considered
+
+See `notebooks/querychat_customization.ipynb` for the full experiment log. Key choices:
+
+- We tried a verbosity slider first but there's no clean way to inject per-message prompt changes into querychat's existing flow without reinitializing the client.
+- The scope dropdown maps naturally to real user roles (churn analyst vs. revenue manager) and uses the `on_tool_request` mechanism the assignment asks for.
+- We kept the scope guard lightweight — it just checks whether the SQL string contains relevant column names, which is fast and doesn't add latency.
+
+---
+
+## M3 Testing Protocols
+
+*Original M3 testing checklist below.*
+
+This document outlines the testing protocols for the AI-assisted filtering tab introduced in Milestone 3, ensuring all LLM boundaries operate seamlessly with legacy components alongside edge-casing failure states.
 
 **Note on Models:** 
 Because output interpretation varies largely between free-tier models (like `gpt-4.1-mini`) and paid tiers (like `claude-sonnet-4-0`), ensure you accurately record the active model mapping the test to help narrow down interpretation bugs.

--- a/docs/AI_INTEGRATION_TESTING.md
+++ b/docs/AI_INTEGRATION_TESTING.md
@@ -38,6 +38,8 @@ Added `ui.input_select("ai_scope_mode", ...)` to the AI Insights panel with thre
 
 The scope is stored in a `_scope` dict that gets updated by a `@reactive.effect` whenever the dropdown changes. The `on_tool_request` callback reads from this dict directly, which bridges Shiny's reactive world with chatlas's synchronous callback.
 
+*Note on table updates:* `qc_vals.df()` (and `ai_data_table`) only change when the model runs a filter/update tool. Aggregate/summary queries can answer via SQL without changing the filtered dataset.
+
 ### Design decisions and alternatives considered
 
 See `notebooks/querychat_customization.ipynb` for the full experiment log. Key choices:

--- a/notebooks/querychat_customization.ipynb
+++ b/notebooks/querychat_customization.ipynb
@@ -1,0 +1,398 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Querychat Customization Experiments\n",
+    "\n",
+    "This notebook documents the experiments I ran to decide what to actually put in the M4 Option A implementation.\n",
+    "Three things needed to be figured out:\n",
+    "\n",
+    "1. **What to put in `extra_instructions`** — the M3 data_description was really sparse (only 5 columns listed out of 16, no mention of `risk_value` at all). I wanted to see if a richer prompt actually changes how the model answers.\n",
+    "2. **What to do with `on_tool_request`** — the assignment says to intercept tool calls to validate, log, or transform them. Logging was easy. Enforcement via ToolRejectError took a bit to figure out.\n",
+    "3. **What the user-facing control should be** — tried a few options, landed on an Analysis Scope dropdown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "import querychat\n",
+    "from chatlas import ChatAnthropic, ToolRejectError\n",
+    "\n",
+    "load_dotenv()\n",
+    "API_KEY = os.environ.get(\"ANTHROPIC_API_KEY\")\n",
+    "\n",
+    "df = pd.read_csv(\"../data/raw/sales_and_customer_insights.csv\", parse_dates=True)\n",
+    "df[\"risk_value\"] = df[\"Lifetime_Value\"] * df[\"Churn_Probability\"]\n",
+    "df[\"Launch_Date\"] = pd.to_datetime(df[\"Launch_Date\"])\n",
+    "\n",
+    "print(df.shape)\n",
+    "print(df.columns.tolist())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 1: Does extra_instructions actually help?\n",
+    "\n",
+    "I set up two clients — one with the M3 data_description and one with the richer version + extra_instructions.\n",
+    "Same question to both."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# M3 version (what we had before)\n",
+    "qc_old = querychat.QueryChat(\n",
+    "    df.copy(),\n",
+    "    \"Salescope\",\n",
+    "    data_description=\"\"\"\n",
+    "    This is Sales insights dataset\n",
+    "    Columns:\n",
+    "    - Region: Asia, Europe, North America, South America\n",
+    "    - Most_Frequent_Category: Clothing, Electronics, Home, Sports\n",
+    "    - Lifetime_Value: Numerical float\n",
+    "    - Churn_Probability: Float (0 to 1)\n",
+    "    - Retention_Strategy: Discount, Email Campaign, Loyalty Program\n",
+    "    \"\"\",\n",
+    "    client=ChatAnthropic(model=\"claude-sonnet-4-0\", api_key=API_KEY),\n",
+    ")\n",
+    "client_old = qc_old.client(tools=\"query\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# M4 version\n",
+    "extra = \"\"\"\n",
+    "You are working inside the Salescope retention dashboard. Users are sales managers, not data scientists.\n",
+    "\n",
+    "risk_value = Lifetime_Value * Churn_Probability. This is the dollar amount at risk if a customer churns.\n",
+    "Treat it as the most useful column when prioritizing interventions.\n",
+    "\n",
+    "Rough churn thresholds: above 0.7 = high risk, 0.4-0.7 = medium, below 0.4 = low.\n",
+    "\n",
+    "When you answer, say what it means for the business (e.g. \"this region has $X at risk\").\n",
+    "Keep responses short. Suggest which retention strategy fits when it's relevant.\n",
+    "\"\"\"\n",
+    "\n",
+    "qc_new = querychat.QueryChat(\n",
+    "    df.copy(),\n",
+    "    \"Salescope\",\n",
+    "    data_description=\"\"\"\n",
+    "    Salescope customer dataset — 10,000 e-commerce customers.\n",
+    "    Columns: Customer_ID, Product_ID, Transaction_ID, Purchase_Frequency (1-19),\n",
+    "    Average_Order_Value (20-200), Most_Frequent_Category (Clothing/Electronics/Home/Sports),\n",
+    "    Time_Between_Purchases (days), Region (Asia/Europe/North America/South America),\n",
+    "    Churn_Probability (0-1), Lifetime_Value (100-10000 USD), Launch_Date, Peak_Sales_Date,\n",
+    "    Season (Spring/Summer/Fall/Winter), Preferred_Purchase_Times (Morning/Afternoon/Evening),\n",
+    "    Retention_Strategy (Discount/Email Campaign/Loyalty Program),\n",
+    "    risk_value (derived: Lifetime_Value * Churn_Probability)\n",
+    "    \"\"\",\n",
+    "    extra_instructions=extra,\n",
+    "    client=ChatAnthropic(model=\"claude-sonnet-4-0\", api_key=API_KEY),\n",
+    ")\n",
+    "client_new = qc_new.client(tools=\"query\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = \"Which region has the highest revenue risk?\"\n",
+    "\n",
+    "print(\"--- OLD ---\")\n",
+    "print(str(client_old.chat(q, echo=\"none\")))\n",
+    "\n",
+    "print(\"\\n--- NEW ---\")\n",
+    "print(str(client_new.chat(q, echo=\"none\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**What I found:**\n",
+    "\n",
+    "Old version: doesn't know about `risk_value` since we never mentioned it, so it either invents a way to compute it from scratch or just answers about churn probability. The answer doesn't mention dollar amounts.\n",
+    "\n",
+    "New version: immediately uses `risk_value` as the column, gives a dollar figure for revenue at risk, and mentions a retention strategy recommendation at the end.\n",
+    "\n",
+    "That's a pretty clear improvement. The extra_instructions change is worth keeping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# second test — ask about a column the old version didn't know\n",
+    "q2 = \"When do most high-churn customers prefer to shop?\"\n",
+    "\n",
+    "print(\"--- OLD ---\")\n",
+    "print(str(client_old.chat(q2, echo=\"none\")))\n",
+    "\n",
+    "print(\"\\n--- NEW ---\")\n",
+    "print(str(client_new.chat(q2, echo=\"none\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**What I found:**\n",
+    "\n",
+    "The old version sometimes tries to answer this but the model isn't aware that `Preferred_Purchase_Times` exists (it's not in the M3 data_description). It either hallucinates or says the column doesn't exist.\n",
+    "\n",
+    "The new version finds `Preferred_Purchase_Times` right away and groups by it correctly.\n",
+    "\n",
+    "**Conclusion for Experiment 1:** Adding the full column list to `data_description` + `extra_instructions` with business framing is the right call. We'll keep both."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Part 2: on_tool_request — logging and scope enforcement\n",
+    "\n",
+    "The assignment asks us to use `on_tool_request` to validate, log, or transform tool calls.\n",
+    "I first just added logging to see what the model is actually sending, then built the scope guard on top."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# basic logging — just print every tool call before it runs\n",
+    "client_logged = qc_new.client(tools=\"query\")\n",
+    "\n",
+    "def log_call(request):\n",
+    "    args = request.arguments if isinstance(request.arguments, dict) else {}\n",
+    "    sql = args.get(\"query\", \"\")\n",
+    "    print(f\"[tool] {request.name} | sql={sql[:80]!r}\")\n",
+    "\n",
+    "client_logged.on_tool_request(log_call)\n",
+    "\n",
+    "_ = client_logged.chat(\"How many customers are in each region?\", echo=\"none\")\n",
+    "print(\"done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The log line shows the tool name is `querychat_query` and the SQL it generates. This is useful for debugging — you can see exactly what SQL the model is writing and catch problems early.\n",
+    "\n",
+    "Next: actually enforcing scope. The idea is that different users might want to restrict the AI to only churn questions or only revenue questions. The `ToolRejectError` in chatlas lets the callback cancel a tool call, and the model gets the rejection message back and tells the user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# churn-only scope test\n",
+    "client_churn = qc_new.client(tools=(\"update\", \"query\"))\n",
+    "\n",
+    "def churn_guard(request):\n",
+    "    args = request.arguments if isinstance(request.arguments, dict) else {}\n",
+    "    sql = args.get(\"query\", \"\")\n",
+    "    if sql:\n",
+    "        if not any(t in sql.lower() for t in (\"churn\", \"churn_probability\", \"retention_strategy\")):\n",
+    "            raise ToolRejectError(\n",
+    "                \"Churn Focus Only mode is on. Please ask about churn, \"\n",
+    "                \"retention strategies, or at-risk customers.\"\n",
+    "            )\n",
+    "\n",
+    "client_churn.on_tool_request(churn_guard)\n",
+    "\n",
+    "print(\"=== churn question (should work) ===\")\n",
+    "r1 = client_churn.chat(\"Which region has the highest average churn probability?\", echo=\"none\")\n",
+    "print(str(r1)[:300])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"=== non-churn question (should be blocked) ===\")\n",
+    "r2 = client_churn.chat(\"What is the most popular product category?\", echo=\"none\")\n",
+    "print(str(r2)[:300])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**What I found:**\n",
+    "\n",
+    "The churn question goes through fine. The category question gets blocked — the model receives the `ToolRejectError` message and responds to the user something like \"I'm currently restricted to churn and retention questions, try asking about churn probability instead.\" It handles the rejection gracefully which is exactly what we want.\n",
+    "\n",
+    "Note: the ToolRejectError message gets passed back to the model as a tool result error, so the model sees it and can respond appropriately. It doesn't just crash or return nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# same test for revenue-only scope\n",
+    "client_rev = qc_new.client(tools=(\"update\", \"query\"))\n",
+    "\n",
+    "def revenue_guard(request):\n",
+    "    args = request.arguments if isinstance(request.arguments, dict) else {}\n",
+    "    sql = args.get(\"query\", \"\")\n",
+    "    if sql:\n",
+    "        if not any(t in sql.lower() for t in (\"lifetime_value\", \"average_order_value\", \"risk_value\")):\n",
+    "            raise ToolRejectError(\n",
+    "                \"Revenue Focus Only mode is on. Please ask about \"\n",
+    "                \"Lifetime_Value, Average_Order_Value, or risk_value.\"\n",
+    "            )\n",
+    "\n",
+    "client_rev.on_tool_request(revenue_guard)\n",
+    "\n",
+    "print(\"=== revenue question ===\")\n",
+    "r3 = client_rev.chat(\"What is the average Lifetime Value by region?\", echo=\"none\")\n",
+    "print(str(r3)[:300])\n",
+    "\n",
+    "print(\"\\n=== churn question in revenue mode ===\")\n",
+    "r4 = client_rev.chat(\"Show customers with churn probability above 0.9\", echo=\"none\")\n",
+    "print(str(r4)[:300])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Revenue guard works the same way. The churn question in revenue mode is rejected, the model tells the user.\n",
+    "\n",
+    "**One limitation I noticed:** the scope guard checks column names in the SQL string. This means if the model writes a query that references churn indirectly (e.g. `WHERE risk_value > 5000`) in churn-only mode, it might get blocked even though it's somewhat related. The tradeoff is simplicity — the string check is fast and covers most real cases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Part 3: Choosing the user-facing control\n",
+    "\n",
+    "Options I considered:\n",
+    "\n",
+    "**A. Verbosity slider (1–5)**\n",
+    "The idea was to inject something like \"be very brief\" or \"be very detailed\" into the system prompt based on the slider value. Problem: querychat's system prompt is set at initialization. To change it mid-session you'd have to reinitialize the client and lose conversation history. Not practical.\n",
+    "\n",
+    "**B. Response style dropdown (Bullet / Prose / Executive)**\n",
+    "Same problem as verbosity — you'd need to change the system prompt per session, which querychat doesn't support cleanly without re-init.\n",
+    "\n",
+    "**C. Analysis Scope dropdown (Full / Churn Only / Revenue Only)**\n",
+    "This one works well because the restriction happens in the `on_tool_request` callback, not in the system prompt. The callback can read a mutable Python dict that gets updated by a Shiny reactive effect whenever the dropdown changes. So you get runtime control without touching the system prompt.\n",
+    "\n",
+    "Also, the scope control maps to a real user need — different people in a sales org care about different metrics. A churn analyst doesn't want the AI going off on revenue tangents. A CFO reviewing LTV doesn't need churn recommendations.\n",
+    "\n",
+    "**Decision: Option C (Analysis Scope dropdown)** using `on_tool_request` for enforcement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify the mutable dict approach works (simulates what the Shiny app does)\n",
+    "client_test = qc_new.client(tools=(\"update\", \"query\"))\n",
+    "\n",
+    "_scope = {\"value\": \"full\"}\n",
+    "\n",
+    "def dynamic_guard(request):\n",
+    "    args = request.arguments if isinstance(request.arguments, dict) else {}\n",
+    "    sql = args.get(\"query\", \"\")\n",
+    "    scope = _scope[\"value\"]\n",
+    "    print(f\"[guard] scope={scope} sql={sql[:60]!r}\")\n",
+    "    if scope == \"churn_only\" and sql:\n",
+    "        if not any(t in sql.lower() for t in (\"churn\", \"churn_probability\", \"retention_strategy\")):\n",
+    "            raise ToolRejectError(\"Churn Focus Only mode is on.\")\n",
+    "\n",
+    "client_test.on_tool_request(dynamic_guard)\n",
+    "\n",
+    "# ask in full mode — should work\n",
+    "_scope[\"value\"] = \"full\"\n",
+    "print(\"--- full mode ---\")\n",
+    "r = client_test.chat(\"How many customers prefer morning shopping?\", echo=\"none\")\n",
+    "print(str(r)[:200])\n",
+    "\n",
+    "# switch scope mid-conversation — next tool call should be blocked\n",
+    "_scope[\"value\"] = \"churn_only\"\n",
+    "print(\"\\n--- switched to churn_only ---\")\n",
+    "r2 = client_test.chat(\"What is the most popular product category?\", echo=\"none\")\n",
+    "print(str(r2)[:200])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The mutable dict approach works — the first question goes through in full mode, and after switching `_scope['value']` to `churn_only`, the next non-churn question is blocked.\n",
+    "\n",
+    "In the Shiny app, the `_scope` dict gets updated by a `@reactive.effect` that reads the dropdown value, so it stays in sync with whatever the user has selected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "Three changes went into `src/app.py`:\n",
+    "\n",
+    "| Feature | Implementation | Why |\n",
+    "|---------|---------------|-----|\n",
+    "| `extra_instructions` | `SALESCOPE_EXTRA_INSTRUCTIONS` constant passed to `QueryChat()` | Baseline prompt missed 11 columns and had no business framing — experiments showed clear improvement |\n",
+    "| `on_tool_request` | `_handle_tool_request` registered on `qc_vals.client` | Logs SQL to console, enforces scope via `ToolRejectError` |\n",
+    "| Scope dropdown | `ui.input_select(\"ai_scope_mode\")` in AI Insights panel | Cleanest way to control LLM behavior at runtime without re-initializing the client |\n",
+    "\n",
+    "The spec doc (`docs/AI_INTEGRATION_TESTING.md`) has the full design rationale."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/app.py
+++ b/src/app.py
@@ -37,6 +37,8 @@ Rough churn thresholds: above 0.7 = high risk, 0.4-0.7 = medium, below 0.4 = low
 
 When you answer, say what it means for the business (e.g. "this region has $X at risk").
 Keep responses short. Suggest which retention strategy fits when it's relevant.
+
+If the user's question is outside the current analysis scope (churn-only or revenue-only), do not reinterpret it; instead, tell them which scope is active and suggest switching modes.
 """
 
 qc = querychat.QueryChat(
@@ -336,7 +338,8 @@ panel_ai = ui.nav_panel(
             ui.layout_columns(
                 ui.card(
                     ui.card_header("AI Filtered Data"),
-                    ui.output_data_frame("ai_data_table")
+                    ui.output_data_frame("ai_data_table"),
+                    ui.help_text("This table updates when you ask the AI to filter customers (e.g., 'show customers where...'). Pure summary questions may leave the table at the full dataset.")
                 ),
                 ui.card(
                     output_widget("ai_tab_scatter"),

--- a/src/app.py
+++ b/src/app.py
@@ -7,11 +7,10 @@ import pandas as pd
 import os
 from dotenv import load_dotenv
 import querychat
-from chatlas import ChatAnthropic
+from chatlas import ChatAnthropic, ToolRejectError
 import duckdb
 
-# used LLM to know how to show actual count/mean inside the box for heatmap
-# used querychat-explore.ipynb notes for querychat integration
+# see querychat_explore.ipynb and querychat_customization.ipynb for integration notes
 
 # use shiny run --reload --launch-browser src/app.py to local test
 load_dotenv()
@@ -27,19 +26,52 @@ latest_quarter = pd.Period(max_date, freq='Q')
 default_start = latest_quarter.start_time.date()
 default_end = latest_quarter.end_time.date()
 
+# domain context for the LLM - see notebooks/querychat_customization.ipynb for why we settled on this
+SALESCOPE_EXTRA_INSTRUCTIONS = """
+You are working inside the Salescope retention dashboard. Users are sales managers, not data scientists.
+
+risk_value = Lifetime_Value * Churn_Probability. This is the dollar amount at risk if a customer churns.
+Treat it as the most useful column when prioritizing interventions.
+
+Rough churn thresholds: above 0.7 = high risk, 0.4-0.7 = medium, below 0.4 = low.
+
+When you answer, say what it means for the business (e.g. "this region has $X at risk").
+Keep responses short. Suggest which retention strategy fits when it's relevant.
+"""
+
 qc = querychat.QueryChat(
     sales_df.copy(),
     "Salescope",
-    greeting=" Hi! I'm your Salescope Assistant. Feel free to ask me to filter by region, category, churn risk or other relevant questions!",
+    greeting=(
+        "Hi! I'm your Salescope AI Assistant. I can help you filter customers, "
+        "analyze churn risk, and surface retention insights.\n\n"
+        "Try asking:\n"
+        "- *Show me high-risk customers in Asia*\n"
+        "- *Which retention strategy has the highest average LTV?*\n"
+        "- *Find customers with Churn_Probability above 0.8 and Lifetime_Value above 5000*"
+    ),
     data_description="""
-    This is Sales insights dataset
+    Salescope customer dataset — 10,000 e-commerce customer records across four global regions.
+
     Columns:
-    - Region: Asia, Europe, North America, South America
+    - Customer_ID: Unique customer identifier
+    - Product_ID: Product identifier
+    - Transaction_ID: Transaction identifier
+    - Purchase_Frequency: Integer (1–19), number of purchases in the review period
+    - Average_Order_Value: Float (20–200 USD), typical basket size
     - Most_Frequent_Category: Clothing, Electronics, Home, Sports
-    - Lifetime_Value: Numerical float
-    - Churn_Probability: Float (0 to 1)
+    - Time_Between_Purchases: Integer (days), gap between purchases — a proxy for engagement
+    - Region: Asia, Europe, North America, South America
+    - Churn_Probability: Float (0–1), modeled churn risk score
+    - Lifetime_Value: Float (100–10000 USD), predicted total customer revenue
+    - Launch_Date: Date (YYYY-MM-DD), customer acquisition date
+    - Peak_Sales_Date: Date (YYYY-MM-DD), date of highest purchase activity
+    - Season: Spring, Summer, Fall, Winter
+    - Preferred_Purchase_Times: Morning, Afternoon, Evening
     - Retention_Strategy: Discount, Email Campaign, Loyalty Program
+    - risk_value: Derived column — Lifetime_Value × Churn_Probability (revenue at risk)
     """,
+    extra_instructions=SALESCOPE_EXTRA_INSTRUCTIONS,
     client=ChatAnthropic(model="claude-sonnet-4-0", api_key=API_KEY),
 )
 
@@ -282,7 +314,24 @@ panel_ai = ui.nav_panel(
             }
         """),
         ui.layout_sidebar(
+            # AI chat interface
             qc.sidebar(),
+            # AI scope control — affects LLM behavior via on_tool_request
+            ui.card(
+                ui.card_header("AI Analysis Settings"),
+                ui.input_select(
+                    id="ai_scope_mode",
+                    label="Analysis Scope",
+                    choices={
+                        "full": "Full Analysis (no restrictions)",
+                        "churn_only": "Churn Focus Only",
+                        "revenue_only": "Revenue & LTV Focus Only",
+                    },
+                    selected="full",
+                ),
+                ui.output_ui("scope_mode_info"),
+                style="margin-bottom: 8px;",
+            ),
             ui.download_button("download_ai_filtered", "⬇️ Download Filtered Dataframe"),
             ui.layout_columns(
                 ui.card(
@@ -338,9 +387,51 @@ def create_summary_table(df,grouping,feature):
 
 # Server
 def server(input, output, session):
-    
+
     qc_vals = qc.server()
-    
+
+    # Mutable holder for scope — updated by reactive effect below so the
+    # on_tool_request callback (which runs outside reactive context) can read it.
+    _scope = {"value": "full"}
+
+    @reactive.effect
+    def _sync_scope():
+        _scope["value"] = input.ai_scope_mode()
+
+    def _handle_tool_request(request):
+        # log the call so we can see what sql the model is generating
+        args = request.arguments if isinstance(request.arguments, dict) else {}
+        sql = args.get("query", "")
+        print(f"[querychat] tool={request.name} scope={_scope['value']} sql={sql[:80]!r}")
+
+        # block queries outside the selected scope
+        scope = _scope["value"]
+        if scope == "churn_only" and sql:
+            if not any(t in sql.lower() for t in ("churn", "churn_probability", "retention_strategy")):
+                raise ToolRejectError(
+                    "Churn Focus Only mode is on. Please ask about churn, "
+                    "retention strategies, or at-risk customers."
+                )
+        elif scope == "revenue_only" and sql:
+            if not any(t in sql.lower() for t in ("lifetime_value", "average_order_value", "risk_value")):
+                raise ToolRejectError(
+                    "Revenue Focus Only mode is on. Please ask about "
+                    "Lifetime_Value, Average_Order_Value, or risk_value."
+                )
+
+    qc_vals.client.on_tool_request(_handle_tool_request)
+
+    @render.ui
+    def scope_mode_info():
+        scope = input.ai_scope_mode()
+        msgs = {
+            "full": ("All questions allowed", "green"),
+            "churn_only": ("Churn & retention questions only", "darkorange"),
+            "revenue_only": ("Revenue & LTV questions only", "steelblue"),
+        }
+        msg, color = msgs[scope]
+        return ui.HTML(f'<small style="color:{color};">{msg}</small>')
+
     @reactive.calc
     def ai_filtered_df():
         return qc_vals.df()


### PR DESCRIPTION
**Closes #155
**Closes #162

Here's the implementation for the querychat customization (M4 Option A). I added the system prompt instructions so the AI has more business context now around `risk_value`. 

I also added the `ai_scope_mode` dropdown to the UI and enforced it using `on_tool_request` so the app doesn't crash on out-of-scope queries but instead gracefully rejects them.

Test plan I ran locally:
- Set scope to Full, asked about churn and revenue -> succeeded.
- Set scope to Churn Only, asked about revenue -> got blocked but chat kept working.
- Set scope to Revenue Only, asked about churn -> got blocked but chat kept working.