### PR TITLE
M4 - clarify analysis flow and churn scenario helper text (#186)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -120,6 +120,10 @@ main_sidebar = ui.sidebar(
         max=100,
         value=0,
     ),
+    ui.help_text(
+        "Scenario slider: simulate reducing the upper churn bound by this percentage. "
+        "KPIs and plots compare this scenario against the original churn range."
+    ),
     ui.input_numeric(
         id="num_clv_min",
         label="Customer Lifetime Value min",
@@ -309,8 +313,8 @@ app_ui = ui.page_navbar(
     ui.nav_panel(
         "Advanced Figures",
         ui.navset_card_tab(
-            panel_1,
             panel_2,
+            panel_1,
             panel_3, 
             id="advanced_nav"
         )
@@ -320,6 +324,10 @@ app_ui = ui.page_navbar(
     sidebar=main_sidebar,
     header=ui.TagList(
         ui.markdown("#### Data-driven customer retention and churn analysis."),
+        ui.markdown(
+            "**Suggested analysis flow:** Start on the *Churn Risk Plot* tab to spot high-risk segments, "
+            "then use *KPI Tables* and the *Seasonal Product Heatmap* to drill into details."
+        ),
         ui.output_ui("conditional_kpis")
     ),
     id="top_navbar",


### PR DESCRIPTION
Closes #186

Addresses the peer review feedback about users not knowing where to start or misunderstanding the churn scenario slider.

1. Added explicit helper text beneath the "Churn rate decrease (%)" slider confirming that it's a simulated scenario, and not a filter of historical data.
2. Re-ordered the Advanced Figures tabs so the "Churn Risk Plot" is now the default view.
3. Added a "Suggested analysis flow" tip physically into the main header instructing users to start on the Churn Risk Plot before drilling down into the Key Metric Tables.