### PR TITLE
Milestone4/sidebar

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -176,7 +176,6 @@ main_sidebar = ui.sidebar(
     """),
     
     ui.markdown("Churn Rate"),
-    # UI Component
     ui.layout_column_wrap(
         ui.input_numeric(
             id="num_churn_min",
@@ -185,7 +184,7 @@ main_sidebar = ui.sidebar(
             min=0.0,
             max=1.0,
             step=0.01,
-            #width="80%"
+            width="100%"
         ),
         ui.input_numeric(
             id="num_churn_max",
@@ -194,13 +193,12 @@ main_sidebar = ui.sidebar(
             min=0.0,
             max=1.0,
             step=0.01,
-            #width="100%"
+            width="100%"
         ),
         width=1/2,
         gap="30px",
     class_="numeric-range-styled"
     ),
-
 
     ui.input_slider(
         id="slider_churn_decrease",
@@ -209,36 +207,76 @@ main_sidebar = ui.sidebar(
         max=100,
         value=0,
     ),
-    ui.input_numeric(
-        id="num_clv_min",
-        label="Customer Lifetime Value min",
-        value=100, min=100, max=10000, step=50
+
+    ui.markdown("Customer Lifetime Value"),
+    ui.layout_column_wrap(  
+        ui.input_numeric(
+            id="num_clv_min",
+            label=None,
+            value=100, 
+            min=100, 
+            max=10000, 
+            step=50
+        ),
+        ui.input_numeric(
+            id="num_clv_max",
+            label=None,
+            value=10000, 
+            min=100, 
+            max=10000, 
+            step=50
+        ),  
+        width=1/2,
+        gap="30px",
+    class_="numeric-range-styled"
     ),
-    ui.input_numeric(
-        id="num_clv_max",
-        label="Customer Lifetime Value max",
-        value=10000, min=100, max=10000, step=50
+
+    ui.markdown("Average Order Value"),
+    ui.layout_column_wrap(
+        ui.input_numeric(
+            id="num_order_min",
+            label=None,
+            value=20, 
+            min=20, 
+            max=200, 
+            step=5
+        ),
+        ui.input_numeric(
+            id="num_order_max",
+            label=None,
+            value=200, 
+            min=20, 
+            max=200, 
+            step=5
+        ),
+        width=1/2,
+        gap="30px",
+    class_="numeric-range-styled"
+    ),    
+
+    ui.markdown("Purchase Frequency"),
+    ui.layout_column_wrap(
+        ui.input_numeric(
+            id="num_freq_min",
+            label=None,
+            value=1, 
+            min=1, 
+            max=19, 
+            step=1
+        ),
+        ui.input_numeric(
+            id="num_freq_max",
+            label=None,
+            value=19, 
+            min=1, 
+            max=19, 
+            step=1
+        ),
+        width=1/2,
+        gap="30px",
+    class_="numeric-range-styled"
     ),
-    ui.input_numeric(
-        id="num_order_min",
-        label="Average Order Value min",
-        value=20, min=20, max=200, step=5
-    ),
-    ui.input_numeric(
-        id="num_order_max",
-        label="Average Order Value max",
-        value=200, min=20, max=200, step=5
-    ),
-    ui.input_numeric(
-        id="num_freq_min",
-        label="Purchase Frequency min",
-        value=1, min=1, max=19, step=1
-    ),
-    ui.input_numeric(
-        id="num_freq_max",
-        label="Purchase Frequency max",
-        value=19, min=1, max=19, step=1
-    ),
+    
     ui.input_date_range(
         id="date_range", 
         label="Filter by launch date",

--- a/src/app.py
+++ b/src/app.py
@@ -175,6 +175,66 @@ main_sidebar = ui.sidebar(
 
     """),
     
+    # Launch date filter
+    
+    ui.input_date_range(
+        id="date_range", 
+        label="Filter by launch date",
+        start=max(default_start,min_date),
+        end=min(default_end,max_date),
+        min=min_date,
+        max=max_date
+    ),
+    
+    # Checkbox filters
+
+    ui.input_checkbox(
+        id="use_ai_filter",
+        label=ui.tags.span("Use the ",ui.tags.code("AI Insights")," dataframe"),
+        value=False,
+    ),
+
+    ui.input_checkbox_group(
+        id="checkbox_group_type",
+        label="Most Common Purchase Type",
+        choices={
+            "Clothing": "Clothing",
+            "Electronics": "Electronics",
+            "Home": "Home",
+            "Sports": "Sports",             
+        },
+        selected=[
+
+        ],
+    ),
+    ui.input_checkbox_group(
+        id="checkbox_group_region",
+        label="Region",
+        choices={
+            "Asia": "Asia",
+            "Europe": "Europe",
+            "North America": "North America",
+            "South America": "South America",
+        },
+        selected=[
+            
+        ],
+    ),
+    ui.input_checkbox_group(
+        id="checkbox_group_strategy",
+        label="Retention Strategy",
+        choices={
+            "Discount": "Discount",
+            "Email Campaign": "Email Campaign",
+            "Loyalty Program": "Loyalty Program"
+        },
+        selected=[
+
+        ],
+    ),
+
+    # Numeric Filters
+
     ui.markdown("Churn Rate"),
     ui.layout_column_wrap(
         ui.input_numeric(
@@ -277,57 +337,8 @@ main_sidebar = ui.sidebar(
     class_="numeric-range-styled"
     ),
     
-    ui.input_date_range(
-        id="date_range", 
-        label="Filter by launch date",
-        start=max(default_start,min_date),
-        end=min(default_end,max_date),
-        min=min_date,
-        max=max_date
-    ),
-    ui.input_checkbox(
-    id="use_ai_filter",
-    label="Use AI filtered data for dashboard",
-    value=False,
-    ),
-    ui.input_checkbox_group(
-        id="checkbox_group_type",
-        label="Most Common Purchase Type",
-        choices={
-            "Clothing": "Clothing",
-            "Electronics": "Electronics",
-            "Home": "Home",
-            "Sports": "Sports",             
-        },
-        selected=[
-
-        ],
-    ),
-    ui.input_checkbox_group(
-        id="checkbox_group_region",
-        label="Region",
-        choices={
-            "Asia": "Asia",
-            "Europe": "Europe",
-            "North America": "North America",
-            "South America": "South America",
-        },
-        selected=[
-            
-        ],
-    ),
-    ui.input_checkbox_group(
-        id="checkbox_group_strategy",
-        label="Retention Strategy",
-        choices={
-            "Discount": "Discount",
-            "Email Campaign": "Email Campaign",
-            "Loyalty Program": "Loyalty Program"
-        },
-        selected=[
-
-        ],
-    ),
+    
+    
     ui.input_action_button("reset", "Reset filters"),
     open="desktop",
 )

--- a/src/app.py
+++ b/src/app.py
@@ -130,23 +130,78 @@ kpi_component = ui.layout_columns(
     fill=False
 )
 
+    
 main_sidebar = ui.sidebar(
-    ui.input_numeric(
-        id="num_churn_min",
-        label="Churn rate min",
-        value=0.0,
-        min=0.0,
-        max=1.0,
-        step=0.01,
+    # CSS Styling, 
+    ui.tags.style("""
+        /* Outer container styling */
+        .numeric-range-styled {
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            overflow: hidden;
+            display: grid !important;
+            align-items: center;
+            width: fit-content;
+        }
+        
+        /* Remove internal borders */
+        .numeric-range-styled .form-control {
+            border: none !important;
+            box-shadow: none !important;
+            text-align: center;
+        }
+
+        /* Adjust last input for the 'to' box */
+        .numeric-range-styled > div:last-child {
+            position: relative;
+        }
+
+        /* Create the 'to' box, position linked to last object */
+        .numeric-range-styled > div:last-child::before {
+            content: "to";
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #eeeeee;
+            border-left: 1px solid #ccc;
+            border-right: 1px solid #ccc;
+            padding: 0 12px;
+            height: 100%;
+            color: #555;
+            position: absolute;
+            left: -35px;
+            z-index: 1;
+        }
+
+    """),
+    
+    ui.markdown("Churn Rate"),
+    # UI Component
+    ui.layout_column_wrap(
+        ui.input_numeric(
+            id="num_churn_min",
+            label=None,
+            value=0.0,
+            min=0.0,
+            max=1.0,
+            step=0.01,
+            #width="80%"
+        ),
+        ui.input_numeric(
+            id="num_churn_max",
+            label=None,
+            value=1.0,
+            min=0.0,
+            max=1.0,
+            step=0.01,
+            #width="100%"
+        ),
+        width=1/2,
+        gap="30px",
+    class_="numeric-range-styled"
     ),
-    ui.input_numeric(
-        id="num_churn_max",
-        label="Churn rate max",
-        value=1.0,
-        min=0.0,
-        max=1.0,
-        step=0.01,
-    ),
+
+
     ui.input_slider(
         id="slider_churn_decrease",
         label="Churn rate decrease (%)",

--- a/src/app.py
+++ b/src/app.py
@@ -767,8 +767,8 @@ def server(input, output, session):
         )
         ui.update_date_range(
             "date_range",
-            start=default_start,
-            end=default_end,
+            start=max(default_start,min_date),
+            end=min(default_end,max_date),
             min=min_date,
             max=max_date,
             session=session


### PR DESCRIPTION
Closes #185. 

There is an additional bug fix in this PR that resolves the bug where resetting the filters leaves the `end_date` blank; now this should reset the filter to show the data only in the most recent quarter.