### PR TITLE
Add tooltip icon for churn rate decrease slider

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -149,14 +149,17 @@ main_sidebar = ui.sidebar(
     ),
     ui.input_slider(
         id="slider_churn_decrease",
-        label="Churn rate decrease (%)",
+        label=ui.tags.span(
+            "Churn rate decrease (%) ",
+            ui.tags.span(
+                "ⓘ",
+                title="Scenario slider: simulate reducing the upper churn bound by this percentage. KPIs and plots compare this scenario against the original churn range.",
+                style="cursor: help;"
+            )
+        ),
         min=0,
         max=100,
         value=0,
-    ),
-    ui.help_text(
-        "Scenario slider: simulate reducing the upper churn bound by this percentage. "
-        "KPIs and plots compare this scenario against the original churn range."
     ),
     ui.input_numeric(
         id="num_clv_min",


### PR DESCRIPTION
Resolve issue #203 

Adds an info tooltip to the "Churn rate decrease (%)" slider.

The helper text introduced in #193 is now shown via a hover tooltip instead of a persistent help_text block, reducing sidebar clutter and improving usability.

<img width="698" height="467" alt="Screenshot 2026-03-13 at 14 14 15" src="https://github.com/user-attachments/assets/ba37b6b2-f3c8-497c-b828-c5357683e046" />
