### PR TITLE
Milestone 4 - Help button linking to README demo

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -14,8 +14,8 @@ import duckdb
 from pathlib import Path
 
 # src imports
-from .dflogic import create_summary_table, filter_sales_data
-from .db import get_base_dataframe, execute_filtered_query
+from dflogic import create_summary_table, filter_sales_data
+from db import get_base_dataframe, execute_filtered_query
 
 
 # used LLM to know how to show actual count/mean inside the box for heatmap

--- a/src/app.py
+++ b/src/app.py
@@ -14,8 +14,8 @@ import duckdb
 from pathlib import Path
 
 # src imports
-from dflogic import create_summary_table, filter_sales_data
-from db import get_base_dataframe, execute_filtered_query
+from .dflogic import create_summary_table, filter_sales_data
+from .db import get_base_dataframe, execute_filtered_query
 
 
 # used LLM to know how to show actual count/mean inside the box for heatmap

--- a/src/app.py
+++ b/src/app.py
@@ -520,6 +520,16 @@ app_ui = ui.page_navbar(
         )
     ),
     panel_ai, 
+    ui.nav_spacer(),
+    ui.nav_control(
+        ui.a(
+            "Help with Demos",
+            href="https://github.com/UBC-MDS/DSCI-532_2026_10_Salescope?tab=readme-ov-file#demo",
+            target="_blank",
+            class_="btn btn-outline-secondary btn-sm",
+            style="margin-top: 5px;"
+        )
+    ),
     title=ui.TagList(
         ui.img(
             src="salescope_logo_icon.png",


### PR DESCRIPTION
HI Team, 
On the top right corner of the dashboard (should be on top bar), added a help button that can link to useful parts of the README showing the demos for dashboard use. (https://github.com/UBC-MDS/DSCI-532_2026_10_Salescope?tab=readme-ov-file#demo)
Closes #204 
Kindly help me know if any improvements are needed. 
Thanks.